### PR TITLE
Ci/deploy gh page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
 name: Deploy Gh Pages
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 concurrency:
   group: deploy-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,12 +21,10 @@ jobs:
           node-version: 16.18.0
 
       - name: Fetch dependencies
-        working-directory: okp4-gatsby
         run: |
           yarn --frozen-lockfile
 
       - name: Build
-        working-directory: okp4-gatsby
         run: |
           yarn build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy Gh Pages
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  publish-gh-pages:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup node environment (for building)
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.18.0
+
+      - name: Fetch dependencies
+        working-directory: okp4-gatsby
+        run: |
+          yarn --frozen-lockfile
+
+      - name: Build
+        working-directory: okp4-gatsby
+        run: |
+          yarn build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.OKP4_TOKEN }}
+          publish_dir: ./build
+          commit-message: |
+            chore: deploy team-wiki github pages
+          cname: work.okp4.com


### PR DESCRIPTION
Deploy team-wiki on GitHub Pages.
Can be changed to deploy only the latest tagged commit, but there is no semantic release yet.

:warning:  To be merged after the creation of a corresponding CNAME DNS record. :warning: 