### PR TITLE
docs: add more content and translations

### DIFF
--- a/docs/organization/team.mdx
+++ b/docs/organization/team.mdx
@@ -15,6 +15,6 @@ import data from "/static/data/team.json";
 <div class="join">
   <a href="https://taleez.com/careers/okp4">
     <h2>🚀</h2>
-    <p>You want to join the team ?</p>
+    <p>Want to join the team?</p>
   </a>
 </div>

--- a/docs/process/agility.md
+++ b/docs/process/agility.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
-sidebar_label: "Agility"
+sidebar_label: "Agility at OKP4"
 id: agility
 hide_table_of_contents: true
 ---
 
-# Agility
+# Agility at OKP4
 
 ## Why agility?
 
@@ -63,39 +63,3 @@ hide_table_of_contents: true
         <p>We have adaptive, collaborative & iterative approach</p>
     </div>
   </div>
-
-### Kanban fundamentals
-
-✭ Pull-based system
-
-✭ Visualizing the workflow
-
-✭ Limiting Work in Progress
-
-✭ Measuring and managing the flow
-
-✭ Continuous learning and feedback
-
-### Product board 📝
-
-| BACKLOG                                                   | TO DO                                          | SPEC IN PROGRESS                              | MOCKUP IN PROGRESS                              | MOCKUP TESTING                              | VALIDATED                                            | CLOSED                              |
-| --------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------- | ----------------------------------------------- | ------------------------------------------- | ---------------------------------------------------- | ----------------------------------- |
-| tasks that have been proposed but are not yet prioritised | tasks that are prioritised but not yet started | task specs that are currently being worked on | task mockups that are currently being worked on | task mockups that are done and being tested | tasks that are validated and waiting for development | tasks that are completed and closed |
-
-### Dev board 💻
-
-| BACKLOG                                                   | TO DO                                          | IN PROGRESS                              | IN REVIEW                               | TO TEST                                       | VALIDATED                                            | BLOCKED                                                        | EPICS                                                               | CLOSED                              |
-| --------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------- | --------------------------------------- | --------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------- |
-| tasks that have been proposed but are not yet prioritised | tasks that are prioritised but not yet started | tasks that are currently being worked on | tasks that are currently in code review | tasks that are finished and ready for testing | tasks that are validated and waiting for development | tasks that are blocked and cannot be worked on for some reason | tasks that represent a major theme, broken down into smaller issues | tasks that are completed and closed |
-
-### Management board 🧑‍💼
-
-| BACKLOG                                                   | TO DO                                          | IN PROGRESS                              | REVIEW                                       | CLOSED                              |
-| --------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------- | -------------------------------------------- | ----------------------------------- |
-| tasks that have been proposed but are not yet prioritised | tasks that are prioritised but not yet started | tasks that are currently being worked on | tasks that are finished and ready for review | tasks that are completed and closed |
-
-### IT & DevOps board ⚙️
-
-| BACKLOG                                                   | TO DO                                          | IN PROGRESS                              | TESTING                               | BLOCKED                                                        | CLOSED                              |
-| --------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------------------------------- | ----------------------------------- |
-| tasks that have been proposed but are not yet prioritised | tasks that are prioritised but not yet started | tasks that are currently being worked on | tasks that are currently being tested | tasks that are blocked and cannot be worked on for some reason | tasks that are completed and closed |

--- a/docs/process/kanban.md
+++ b/docs/process/kanban.md
@@ -56,6 +56,6 @@ There is a certain criteria a user story must pass in order to be ready for deve
 - mockups (for all devices and themes)
 - labels added
 - US presented to DEV team (refinement meeting)
-- attached to an epic
+- attachment to an epic
 - estimation (planning poker meeting)
 - external dependencies if applicable

--- a/docs/process/kanban.md
+++ b/docs/process/kanban.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 2
+sidebar_label: "Kanban"
+id: kanban
+hide_table_of_contents: true
+---
+
+# Kanban
+
+At OKP4, we are using Kanban as our agile methodology because it offers a visual representation of our work progress, helps us in prioritizing tasks and allows us to continuously deliver new features, which leads to increased efficiency and faster time-to-market.
+
+## Kanban fundamentals
+
+✭ Pull-based system
+
+✭ Visualizing the workflow
+
+✭ Limiting Work in Progress
+
+✭ Measuring and managing the flow
+
+✭ Continuous learning and feedback
+
+## Our Kanban boards
+
+### Product board 📝
+
+| BACKLOG                                                   | TO DO                                          | SPEC IN PROGRESS                              | MOCKUP IN PROGRESS                              | MOCKUP TESTING                              | VALIDATED                                            | CLOSED                              |
+| --------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------- | ----------------------------------------------- | ------------------------------------------- | ---------------------------------------------------- | ----------------------------------- |
+| tasks that have been proposed but are not yet prioritised | tasks that are prioritised but not yet started | task specs that are currently being worked on | task mockups that are currently being worked on | task mockups that are done and being tested | tasks that are validated and waiting for development | tasks that are completed and closed |
+
+### Dev board 💻
+
+| BACKLOG                                                   | TO DO                                          | IN PROGRESS                              | IN REVIEW                               | TO TEST                                       | VALIDATED                                            | BLOCKED                                                        | EPICS                                                               | CLOSED                              |
+| --------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------- | --------------------------------------- | --------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------- |
+| tasks that have been proposed but are not yet prioritised | tasks that are prioritised but not yet started | tasks that are currently being worked on | tasks that are currently in code review | tasks that are finished and ready for testing | tasks that are validated and waiting for development | tasks that are blocked and cannot be worked on for some reason | tasks that represent a major theme, broken down into smaller issues | tasks that are completed and closed |
+
+### Management board 🧑‍💼
+
+| BACKLOG                                                   | TO DO                                          | IN PROGRESS                              | REVIEW                                       | CLOSED                              |
+| --------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------- | -------------------------------------------- | ----------------------------------- |
+| tasks that have been proposed but are not yet prioritised | tasks that are prioritised but not yet started | tasks that are currently being worked on | tasks that are finished and ready for review | tasks that are completed and closed |
+
+### IT & DevOps board ⚙️
+
+| BACKLOG                                                   | TO DO                                          | IN PROGRESS                              | TESTING                               | BLOCKED                                                        | CLOSED                              |
+| --------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------------------------------- | ----------------------------------- |
+| tasks that have been proposed but are not yet prioritised | tasks that are prioritised but not yet started | tasks that are currently being worked on | tasks that are currently being tested | tasks that are blocked and cannot be worked on for some reason | tasks that are completed and closed |
+
+## Definition of Ready ✅
+
+There is a certain criteria a user story must pass in order to be ready for development. A user story that is ready to be developed at OKP4 must have:
+
+- title, description, and value statement
+- acceptance criteria (scenarios)
+- mockups (for all devices and themes)
+- labels added
+- US presented to DEV team (refinement meeting)
+- attached to an epic
+- estimation (planning poker meeting)
+- external dependencies if applicable

--- a/docs/process/recruitment.mdx
+++ b/docs/process/recruitment.mdx
@@ -50,6 +50,6 @@ import OnBoardingImg from "/static/img/recruitment/on-boarding.png";
 <div class="join">
   <a href="https://taleez.com/careers/okp4">
     <h2>🚀</h2>
-    <p>You want to join the team ?</p>
+    <p>Want to join the team?</p>
   </a>
 </div>

--- a/docs/process/rituals.md
+++ b/docs/process/rituals.md
@@ -1,18 +1,18 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: "Our rituals"
 hide_table_of_contents: true
 ---
 
 # Our rituals
 
-📆 **Daily meetings**
+📆 **Daily meeting**
 
 - Tech team
 - Using and updating our Kanban board regularly
 - Keeping on track the WIP
 
-📆 **Weekly meetings**
+📆 **Weekly meeting**
 
 - Tech team and Product team
 - Presentation and discussion of the week’s priorities
@@ -28,7 +28,18 @@ hide_table_of_contents: true
 - All teams
 - Improving our processes and way of working
 
-📆 **Projects meetings**
+📆 **Projects meeting**
 
 - Project and Marketing & Com teams
 - Review of all the current and upcoming projects
+
+📆 **Backlog refinement meeting**
+
+- Weekly meeting between Product and Tech team
+- Product team presents new user stories to the Tech team
+- The tasks get refined according to the feedback
+
+📆 **Planning poker meeting**
+
+- Weekly meeting between Product and Tech team
+- For estimating the work effort for new user stories

--- a/i18n/fr/docusaurus-plugin-content-docs/current/process/agility.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/process/agility.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
-sidebar_label: "Agilité"
+sidebar_label: "Agilité chez OKP4"
 id: agility
 hide_table_of_contents: true
 ---
 
-# Agilité
+# Agilité chez OKP4
 
 ## Pourquoi l'agilité ?
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/process/kanban.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/process/kanban.md
@@ -25,37 +25,37 @@ Chez OKP4, nous utilisons Kanban comme méthodologie agile parce qu'elle offre u
 
 ### Tableau Produit 📝
 
-| BACKLOG                                     | TO DO                                | SPEC EN COURS                    | MAQUETTES EN COURS          | TEST DE MAQUETTES                                 | VALIDÉ                                         | FERMÉ                        |
-| ------------------------------------------- | ------------------------------------ | -------------------------------- | --------------------------- | ------------------------------------------------- | ---------------------------------------------- | ---------------------------- |
-| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencée | tâches de spécification en cours | tâches de maquette en cours | tâches de maquettes terminées et en cours de test | tâches validées et en attente de développement | tâches complétées et fermées |
+| BACKLOG                                     | TO DO                                 | SPEC EN COURS                    | MAQUETTES EN COURS          | TEST DE MAQUETTES                                 | VALIDÉ                                         | FERMÉ                        |
+| ------------------------------------------- | ------------------------------------- | -------------------------------- | --------------------------- | ------------------------------------------------- | ---------------------------------------------- | ---------------------------- |
+| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencées | tâches de spécification en cours | tâches de maquette en cours | tâches de maquettes terminées et en cours de test | tâches validées et en attente de développement | tâches complétées et fermées |
 
 ### Tableau DEV 💻
 
-| BACKLOG                                     | TO DO                                | EN COURS        | EN REVUE                                  | EN TEST                                   | VALIDÉ                                         | BLOQUÉ                                                                       | EPICS                                                                     | FERMÉ                        |
-| ------------------------------------------- | ------------------------------------ | --------------- | ----------------------------------------- | ----------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ---------------------------- |
-| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencée | tâches en cours | tâches dont le code est en cours de revue | tâches terminées et prêtes à être testées | tâches validées et en attente de développement | tâches bloquées sur lesquelles on ne peut pas avancer pour certaines raisons | tâches qui représentent un thème majeur, découpées en plus petits tickets | tâches complétées et fermées |
+| BACKLOG                                     | TO DO                                 | EN COURS        | EN REVUE                                  | EN TEST                                   | VALIDÉ                                         | BLOQUÉ                                                                       | EPICS                                                                     | FERMÉ                        |
+| ------------------------------------------- | ------------------------------------- | --------------- | ----------------------------------------- | ----------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ---------------------------- |
+| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencées | tâches en cours | tâches dont le code est en cours de revue | tâches terminées et prêtes à être testées | tâches validées et en attente de développement | tâches bloquées sur lesquelles on ne peut pas avancer pour certaines raisons | tâches qui représentent un thème majeur, découpées en plus petits tickets | tâches complétées et fermées |
 
 ### Tableau Management 🧑‍💼
 
-| BACKLOG                                     | TO DO                                | EN COURS        | EN REVUE                                     | FERMÉ                        |
-| ------------------------------------------- | ------------------------------------ | --------------- | -------------------------------------------- | ---------------------------- |
-| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencée | tâches en cours | tâches terminées et prêtes à passer en revue | tâches complétées et fermées |
+| BACKLOG                                     | TO DO                                 | EN COURS        | EN REVUE                                     | FERMÉ                        |
+| ------------------------------------------- | ------------------------------------- | --------------- | -------------------------------------------- | ---------------------------- |
+| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencées | tâches en cours | tâches terminées et prêtes à passer en revue | tâches complétées et fermées |
 
 ### Tableau IT & DevOps ⚙️
 
-| BACKLOG                                     | TO DO                                | EN COURS        | EN TEST                 | BLOQUÉ                                                                       | FERMÉ                        |
-| ------------------------------------------- | ------------------------------------ | --------------- | ----------------------- | ---------------------------------------------------------------------------- | ---------------------------- |
-| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencée | tâches en cours | tâches en cours de test | tâches bloquées sur lesquelles on ne peut pas avancer pour certaines raisons | tâches complétées et fermées |
+| BACKLOG                                     | TO DO                                 | EN COURS        | EN TEST                 | BLOQUÉ                                                                       | FERMÉ                        |
+| ------------------------------------------- | ------------------------------------- | --------------- | ----------------------- | ---------------------------------------------------------------------------- | ---------------------------- |
+| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencées | tâches en cours | tâches en cours de test | tâches bloquées sur lesquelles on ne peut pas avancer pour certaines raisons | tâches complétées et fermées |
 
 ## La Definition of Ready ✅
 
-Une user story doit répondre à certains critères pour être prête à être développée. Une user story qui est prête à être développée à l'OKP4 doit avoir :
+Une user story doit répondre à certains critères pour être prête à être développée. Une user story qui est prête à être développée à OKP4 doit avoir :
 
 - titre, description et déclaration de valeur
 - critères d'acceptation (scénarios)
 - maquettes (pour tous les appareils et thèmes)
 - ajout des tags
-- US présenté à l'équipe DEV (réunion d'amélioration)
-- attaché à une epic
-- estimation (réunion de planification)
+- US présentée à l'équipe DEV (réunion de raffinage)
+- rattachement à une epic
+- estimation (réunion de planning poker)
 - dépendances externes le cas échéant

--- a/i18n/fr/docusaurus-plugin-content-docs/current/process/kanban.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/process/kanban.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 2
+sidebar_label: "Kanban"
+id: kanban
+hide_table_of_contents: true
+---
+
+# Kanban
+
+Chez OKP4, nous utilisons Kanban comme méthodologie agile parce qu'elle offre une représentation visuelle de l'avancement de notre travail, nous aide à hiérarchiser les tâches et nous permet de livrer continuellement de nouvelles fonctionnalités, ce qui se traduit par une efficacité accrue et un délai de mise sur le marché plus court.
+
+## Principes de base du Kanban
+
+✭ Système à flux tendu
+
+✭ Visualisation du flux de travail
+
+✭ Limiter le travail en cours
+
+✭ Mesurer et gérer le flux
+
+✭ Apprentissage continu et retour d'information
+
+## Nos tableaux Kanban
+
+### Tableau Produit 📝
+
+| BACKLOG                                     | TO DO                                | SPEC EN COURS                    | MAQUETTES EN COURS          | TEST DE MAQUETTES                                 | VALIDÉ                                         | FERMÉ                        |
+| ------------------------------------------- | ------------------------------------ | -------------------------------- | --------------------------- | ------------------------------------------------- | ---------------------------------------------- | ---------------------------- |
+| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencée | tâches de spécification en cours | tâches de maquette en cours | tâches de maquettes terminées et en cours de test | tâches validées et en attente de développement | tâches complétées et fermées |
+
+### Tableau DEV 💻
+
+| BACKLOG                                     | TO DO                                | EN COURS        | EN REVUE                                  | EN TEST                                   | VALIDÉ                                         | BLOQUÉ                                                                       | EPICS                                                                     | FERMÉ                        |
+| ------------------------------------------- | ------------------------------------ | --------------- | ----------------------------------------- | ----------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ---------------------------- |
+| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencée | tâches en cours | tâches dont le code est en cours de revue | tâches terminées et prêtes à être testées | tâches validées et en attente de développement | tâches bloquées sur lesquelles on ne peut pas avancer pour certaines raisons | tâches qui représentent un thème majeur, découpées en plus petits tickets | tâches complétées et fermées |
+
+### Tableau Management 🧑‍💼
+
+| BACKLOG                                     | TO DO                                | EN COURS        | EN REVUE                                     | FERMÉ                        |
+| ------------------------------------------- | ------------------------------------ | --------------- | -------------------------------------------- | ---------------------------- |
+| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencée | tâches en cours | tâches terminées et prêtes à passer en revue | tâches complétées et fermées |
+
+### Tableau IT & DevOps ⚙️
+
+| BACKLOG                                     | TO DO                                | EN COURS        | EN TEST                 | BLOQUÉ                                                                       | FERMÉ                        |
+| ------------------------------------------- | ------------------------------------ | --------------- | ----------------------- | ---------------------------------------------------------------------------- | ---------------------------- |
+| tâches proposées mais pas encore priorisées | tâches priorisées mais pas commencée | tâches en cours | tâches en cours de test | tâches bloquées sur lesquelles on ne peut pas avancer pour certaines raisons | tâches complétées et fermées |
+
+## La Definition of Ready ✅
+
+Une user story doit répondre à certains critères pour être prête à être développée. Une user story qui est prête à être développée à l'OKP4 doit avoir :
+
+- titre, description et déclaration de valeur
+- critères d'acceptation (scénarios)
+- maquettes (pour tous les appareils et thèmes)
+- ajout des tags
+- US présenté à l'équipe DEV (réunion d'amélioration)
+- attaché à une epic
+- estimation (réunion de planification)
+- dépendances externes le cas échéant

--- a/i18n/fr/docusaurus-plugin-content-docs/current/process/rituals.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/process/rituals.md
@@ -6,13 +6,13 @@ hide_table_of_contents: true
 
 # Nos rituels
 
-📆 **Réunions quotidiennes**
+📆 **Réunion quotidienne**
 
 - Équipe technique
 - Utilisation et mise à jour régulière de notre tableau Kanban
 - Suivi du WIP
 
-📆 **Réunions hebdomadaires**
+📆 **Réunion hebdomadaire**
 
 - Équipe technique et équipe produit
 - Présentation et discussion des priorités de la semaine
@@ -28,18 +28,18 @@ hide_table_of_contents: true
 - Toutes les équipes
 - Améliorer nos processus et nos méthodes de travail
 
-📆 **Réunions de projets**
+📆 **Réunion de projets**
 
-- Équipes de projet et de marketing et communication
+- Équipes projets et marketing et communication
 - Examen de tous les projets en cours et à venir
 
-📆 **Le backlog refinement**
+📆 **Le raffinage du backlog**
 
 - Réunion hebdomadaire entre l'équipe produit et l'équipe technique
-- L'équipe produit présente de nouvelles user story à l'équipe technique.
+- L'équipe produit présente de nouvelles user stories à l'équipe technique.
 - Les tâches sont affinées en fonction du retour d'information
 
 📆 **Le planning poker**
 
 - Réunion hebdomadaire entre l'équipe produit et l'équipe technique
-- Pour estimer l'effort de travail pour les nouvelles user story
+- Pour estimer l'effort de travail pour les nouvelles user stories

--- a/i18n/fr/docusaurus-plugin-content-docs/current/process/rituals.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/process/rituals.md
@@ -1,34 +1,45 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: "Nos rituels"
 hide_table_of_contents: true
 ---
 
 # Nos rituels
 
-📆 Réunions quotidiennes
+📆 **Réunions quotidiennes**
 
 - Équipe technique
 - Utilisation et mise à jour régulière de notre tableau Kanban
 - Suivi du WIP
 
-📆 Réunions hebdomadaires
+📆 **Réunions hebdomadaires**
 
 - Équipe technique et équipe produit
 - Présentation et discussion des priorités de la semaine
 - Vérification des éléments "à faire
 
-📆 Revue
+📆 **Revue**
 
 - Tout le monde (interne ET externe)
 - Partage et célébration de nos progrès
 
-📆 Rétrospective
+📆 **Rétrospective**
 
 - Toutes les équipes
 - Améliorer nos processus et nos méthodes de travail
 
-📆 Réunions de projets
+📆 **Réunions de projets**
 
 - Équipes de projet et de marketing et communication
 - Examen de tous les projets en cours et à venir
+
+📆 **Le backlog refinement**
+
+- Réunion hebdomadaire entre l'équipe produit et l'équipe technique
+- L'équipe produit présente de nouvelles user story à l'équipe technique.
+- Les tâches sont affinées en fonction du retour d'information
+
+📆 **Le planning poker**
+
+- Réunion hebdomadaire entre l'équipe produit et l'équipe technique
+- Pour estimer l'effort de travail pour les nouvelles user story

--- a/sidebars.js
+++ b/sidebars.js
@@ -70,6 +70,10 @@ const sidebars = {
                 },
                 {
                     type: "doc",
+                    id: "process/kanban",
+                },
+                {
+                    type: "doc",
                     id: "process/rituals",
                 },
                 {


### PR DESCRIPTION
This PR adds more content regarding agility, kanban and rituals. Basically it adds content about our DOR, newly introduced rituals (backlog refinement, planning poker) and their translations.

🚨 Please check the french translation, I have no idea if what I added here makes sense or not. 

To be able to check translations in the localhost, run `yarn build` and then `yarn run serve`